### PR TITLE
feat: use docfx command in docfx-build-documentation.yml

### DIFF
--- a/.github/workflows/docfx-build-documentation.yml
+++ b/.github/workflows/docfx-build-documentation.yml
@@ -12,13 +12,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
-
-      - name: Build docfx metadata
-        uses: nunit/docfx-action@v2.4.0
-        with:
-          args: "metadata Help/doc_source/docfx.json"
-
+        
       - name: Build docfx html
         uses: nunit/docfx-action @v2.4.0
         with:
-          args: "build Help/doc_source/docfx.json"
+          args: "Help/doc_source/docfx.json"


### PR DESCRIPTION
Uses the docfx command with global setting pdf as false. This way it should run the metadata and build commands inside one action.